### PR TITLE
Implement lock-table-based migration strategy

### DIFF
--- a/lms/djangoapps/courseware/management/commands/migrate_student_module_history.py
+++ b/lms/djangoapps/courseware/management/commands/migrate_student_module_history.py
@@ -5,13 +5,21 @@ from textwrap import dedent
 import time
 from optparse import make_option
 from sys import exit
+import traceback
+import os, socket
+from contextlib import closing
+import logging
 
 from django.core.management.base import BaseCommand
-from django.db import transaction
+from django.db import transaction, connection, DatabaseError
 
 from courseware.models import StudentModuleHistory, StudentModuleHistoryArchive
 
-SQL_MAX_INT = 2**31 - 1
+#Should be sufficiently large so as to prevent excessive round-tripping
+#Not user-configurable because choosing a too-large window will cause all inserts via `bulk_create` to fail
+WINDOW = 1000
+LOCK_TABLE_NAME = 'csmh_migration_locks'
+WORKER_ID = socket.gethostname() + '_' + os.getpid()
 
 class Command(BaseCommand):
     """
@@ -20,63 +28,114 @@ class Command(BaseCommand):
     """
     help = dedent(__doc__).strip()
     option_list = BaseCommand.option_list + (
-        make_option('-i', '--index', type='int', default=0, dest='index',
-            help='chunk index to sync (0-indexed) [default: %default]'),
-        make_option('-n', '--num-chunks', type='int', default=1, dest='num_chunks',
-            help='number of chunks to use [default: %default]'),
-        make_option('-w', '--window', type='int', default=1000, dest='window',
-            help='how many rows to migrate per query [default: %default]'),
-        make_option('-s', '--show-range', action='store_true', default=False, dest='show_range',
-            help="show the range that this command would've run over and the max id in that range")
+        make_option('-I', '--initialize', action='store_true', default=False, dest='initialize',
+            help='initialize the migration by creating the lock table, then exit. Run this before starting the migration.')
+        make_option('-c' '--cleanup', action='store_true', default=False, dest='cleanup',
+            help='delete the lock table, then exit. Run this after the migration is complete.')
     )
 
     def handle(self, *arguments, **options):
-        if options['index'] >= options['num_chunks']:
-            self.stdout.write("Index {} is too large for {} chunks\n".format(options['index'], options['num_chunks']))
-            exit(2)
-
-        #Set max and min id from the number of chunks and the selected index
-        chunk_size = SQL_MAX_INT / options['num_chunks']
-        min_id = chunk_size * options['index']
-
-        if options['index'] == options['num_chunks'] - 1:
-            max_id = SQL_MAX_INT
-        else:
-            max_id = chunk_size * options['index'] + chunk_size - 1
-
         try:
-            #Start at the max id in the selected range, so the migration is resumable
-            min_id_already_migrated = StudentModuleHistory.objects.filter(id__lt=max_id, id__gte=min_id).order_by('id')[0].id
-            self.stdout.write("Found min existent id {} in StudentModuleHistory, resuming from there\n".format(min_id_already_migrated))
+            StudentModuleHistoryArchive.objects.all()[0]
         except IndexError:
-            #Assume we're starting from the top of the range
-            min_id_already_migrated = max_id
-            self.stdout.write("No entries found in StudentModuleHistory in this range, starting at top of range ({})\n".format(min_id_already_migrated))
+            self.stdout.write("No entries found in StudentModuleHistoryArchive, aborting migration.\n")
+            exit(1)
 
-        #Make sure there's entries to migrate in StudentModuleHistoryArchive in this range
+        initialized = self._check_initialized()
+
+        if options['cleanup']:
+            self._cleanup():
+            return
+        elif options['initialize']:
+            if initialized:
+                self.stdout.write("Migration is already initialized\n")
+                return
+            else:
+                self._initialize()
+                return
+        else:
+            if initialized:
+                self._migrate()
+                return
+            else:
+                self.stderr.write('The migration is not initialized. Run this command with "--initialize", then try again\n')
+                exit(2)
+
+
+    @transaction.commit_manually    #So that when we log a success message, there's no chance that it actually failed
+    def _initialize():
+        '''Initialize the lock table for the migration'''
+        logging.info("Initializing migration (creating lock table)...")
+        with closing(connection.cursor()):
+            try:
+                cursor.execute(dedent('''
+                    CREATE TABLE %s (
+                        id INT NOT NULL UNIQUE,
+                        processor CHAR(255) DEFAULT NULL,
+                        PRIMARY KEY (id),
+                        INDEX ready (id, processor)
+                    )
+                    '''), [LOCK_TABLE_NAME]
+                )
+                cursor.execute("INSERT INTO %s (id) SELECT id FROM courseware_studentmodulehistory",
+                    [LOCK_TABLE_NAME])
+            except:
+                transaction.rollback()
+            else:
+                transaction.commit()
+
+        logging.info("Migration initialization complete")
+
+
+    def _cleanup():
+        '''Delete the lock table'''
         try:
-            StudentModuleHistoryArchive.objects.filter(id__lt=min_id_already_migrated, id__gte=min_id)[0]
+            with closing(connection.cursor()):
+                cursor.execute("DROP TABLE %s", [LOCK_TABLE_NAME])
         except:
-            self.stdout.write("No entries found in StudentModuleHistoryArchive in range {}-{}, aborting migration.\n".format(
-                min_id_already_migrated, min_id))
-            return
-
-        #If the whole range is migrated, do nothing
-        if min_id_already_migrated == min_id:
-            self.stdout.write("Range {}-{} is already fully migrated, exiting...\n".format(max_id, min_id))
-            return
-
-        if options['show_range']:
-            self.stdout.write("Range: {}-{}, min id in range: {}\n".format(max_id, min_id, min_id_already_migrated))
-            return
-
-        self._migrate_range(min_id, min_id_already_migrated, options['window'])
+            self.stderr.write("Something went wrong while trying to delete the lock table!\n")
+            raise
 
 
-    @transaction.commit_manually
-    def _migrate_range(self, min_id, max_id, window):
-        self.stdout.write("Migrating StudentModuleHistoryArchive entries {}-{}\n".format(max_id, min_id))
-        start_time = time.time()
+    def _check_initialized():
+        '''Is the lock table initialized?'''
+        try:
+            with closing(connection.cursor()):
+                cursor.execute("SELECT id FROM %s ORDER BY id DESC LIMIT 1",
+                    [LOCK_TABLE_NAME])
+                max_lock_id = cursor.fetchall()[0][0]
+
+                cursor.execute("SELECT id FROM %S ORDER BY id LIMIT 1",
+                    [LOCK_TABLE_NAME])
+                min_lock_id = cursor.fetchall()[0][0]
+
+                cursor.execute("SELECT id FROM courseware_studentmodulehistory ORDER BY id DESC LIMIT 1")
+                max_id = cursor.fetchall[0][0]
+
+                cursor.execute("SELECT id FROM courseware_studentmodulehistory ORDER BY id LIMIT 1")
+                min_id = cursor.fetchall[0][0]
+
+        except DatabaseError as e:
+            if e.args[0] = 1146:    #Table doesn't exist error code
+                return False
+            else:
+                self.stderr.write("Something went wrong while checking lock table initialization!\n")
+                raise e
+        else:
+            fail = False
+            if min_id != min_lock_id:
+                self.stderr.write("Min ID in lock table: {}, min ID in StudentModuleHistoryArchive: {}\n".format(min_lock_id, min_id))
+                fail = True
+            if max_id != max_lock_id:
+                self.stderr.write("Max ID in lock table: {}, max ID in StudentModuleHistoryArchive: {}\n".format(max_lock_id, max_id))
+                fail = True
+
+            return not fail
+
+
+    def _migrate(self):
+        '''Perform the migration'''
+        logging.info("Migrating StudentModuleHistoryArchive")
 
         archive_entries = (
             StudentModuleHistoryArchive.objects
@@ -84,41 +143,129 @@ class Command(BaseCommand):
             .order_by('-id')
         )
 
-        real_max_id = None
-        count = 0
-        current_max_id = max_id
+        old_min_id = None
+        old_tick_timestamp = None
+        
+        while True:
+            start_time = time.time()
 
-        try:
-            while current_max_id > min_id:
-                entries = archive_entries.filter(id__lt=current_max_id, id__gte=max(current_max_id - window, min_id))
+            try:
+                ids = self._acquire_lock()
+            except:
+                logging.error("Failed to acquire lock:")
+                traceback.print_exc()
+                continue    #or exit/raise?
+
+            if not ids:
+                logging.info("Migration complete")
+                break
+
+            try:
+                #Using __range instead of __in to avoid truncating if `WINDOW` is large
+                #`_acquire_lock` operates on contiguous ranges, so it shouldn't be a problem
+                entries = archive_entries.filter(pk__range=(ids[0], ids[-1]))
 
                 new_entries = [StudentModuleHistory.from_archive(entry) for entry in entries]
 
+                #This is a single sql statement, so no need for a transaction
+                #This will throw a DatabaseError if `WINDOW` is too large
                 StudentModuleHistory.objects.bulk_create(new_entries)
-                count += len(new_entries)
 
-                if new_entries:
-                    if real_max_id is None:
-                        real_max_id = new_entries[0].id
+            except:
+                try:
+                    self._release_lock(ids)
+                except:
+                    logging.error(("Could not release lock! "
+                        "The following IDs may have NOT been migrated but are still locked: {}").format(
+                        ','.join(map(str, ids))))
+                    traceback.print_exc()   #or exit/raise?
 
-                    transaction.commit()
-                    duration = time.time() - start_time
+                raise   #Do we really want it to exit here?
 
-                    self.stdout.write("Migrated StudentModuleHistoryArchive {}-{} to StudentModuleHistory\n".format(new_entries[0].id, new_entries[-1].id))
-                    self.stdout.write("Migrating {} entries per second. {} seconds remaining...\n".format(
-                        count / duration,
-                        timedelta(seconds=(new_entries[-1].id - min_id) / count * duration),
-                    ))
-
-                current_max_id -= window
-        except:
-            transaction.rollback()
-            raise
-        else:
-            transaction.commit()
-
-            if new_entries:
-                self.stdout.write("Migrated StudentModuleHistoryArchive {}-{} to StudentModuleHistory\n".format(real_max_id, new_entries[-1].id))
-                self.stdout.write("Migration complete\n")
             else:
-                self.stdout.write("No migration needed\n")
+                try:
+                    self._release_lock_and_unqueue(ids)
+                except:
+                    logging.error(("Could not release lock! "
+                        "The following IDs may have been migrated but are still locked: {}").format(
+                        ','.join(map(str, ids))))
+                    traceback.print_exc()
+                    #what now?
+
+            #Logging
+            duration = time.time() - start_time
+
+            logging.info("Migrated StudentModuleHistoryArchive {}-{} to StudentModuleHistory".format(
+                new_entries[0].id, new_entries[-1].id))
+            logging.info("Migrated {} entries in {} seconds, {} entries per second".format(
+                count, duration, count / duration))
+
+            #Fancy math for remaining prediction
+            new_tick_timestamp = time.time()
+            if old_min_id is not None:
+                num_just_migrated = new_entries[0].id - new_entries[-1].id
+                num_migrated_by_others = old_min_id - new_entries[0].id
+                total_migrated_this_cycle = num_just_migrated + num_migrated_by_others
+                cycles_remaining = new_entries[-1].id / total_migrated_this_cycle
+
+                time_since_last_tick = new_tick_timestamp - old_tick_timestamp
+
+                logging.info("{} seconds remaining...".format(
+                    timedelta(seconds=cycles_remaining / time_since_last_tick)))
+
+            old_min_id = new_entries[0].id
+            old_tick_timestamp = new_tick_timestamp
+
+
+    @transaction.commit_on_success
+    def _acquire_lock():
+        '''Acquire a lock on `WINDOW` newest CSMHA entries and return a sorted list of their IDs (highest first)'''
+        with closing(connection.cursor()) as cursor:
+            cursor.execute("SELECT id FROM %s WHERE processor IS NULL ORDER BY id DESC LIMIT %d FOR UPDATE;",
+                [LOCK_TABLE_NAME, WINDOW])
+            ids = cursor.fetchall()
+
+            cursor.execute("UPDATE %s SET processor = %s WHERE id <= %d AND id >= %d",
+                [LOCK_TABLE_NAME, WORKER_ID, ids[0], ids[-1]]
+            )
+
+        return [i[0] for i in ids]
+
+    @transaction.commit_on_success
+    def _release_lock(ids):
+        '''Release my lock on `ids`'''
+        with closing(connection.cursor()) as cursor:
+            self._check_lock(cursor, ids)
+            cursor.execute("UPDATE %s SET processor = NULL WHERE id <= %d AND id >= %d",
+                [LOCK_TABLE_NAME, ids[0], ids[-1]]
+            )
+
+    @transaction.commit_on_success
+    def _release_lock_and_unqueue(ids):
+        '''Delete `ids` from the lock table'''
+        with closing(connection.cursor()) as cursor:
+            self._check_lock(cursor, ids)
+            cursor.execute("DELETE FROM %s WHERE id <= %d AND id >= %d",
+                [LOCK_TABLE_NAME, ids[0], ids[-1]]
+            )
+
+    def _check_lock(cursor, ids):
+        '''
+        Verify supposed invariants:
+            - That all the rows we thought were locked are still locked by us
+            - That our ID range contains the same IDs as when we acquired the lock
+        '''
+        cursor.execute("SELECT * FROM %s WHERE id <= %d AND id >= %d FOR UPDATE",
+            [LOCK_TABLE_NAME, ids[0], ids[-1]]
+        )
+
+        found_rows = cursor.fetchall()
+        not_locked = [i[1] != WORKER_ID for i in found_ids]
+        found_ids = [i[0] for i in found_ids]
+
+        if not_locked:
+            raise Exception("Some rows I thought I had locked are no longer locked by me!: Lock IDs: [{}]".format(
+                ','.join(map(str, not_locked))))
+        if ids != found_ids:
+            raise Exception("Lock rows do not match expected IDs! IDs: [{}] Lock ids: [{}]".format(
+                ','.join(map(str, ids)), ','.join(map(str, found_ids))))


### PR DESCRIPTION
In the new strategy, we create a "lock table" table mirroring CSMHA's
IDs with an extra column showing lock status. Before attempting to
migrate CSMHA rows, workers first put their worker id in the lock column
of the first N unlocked rows of the "lock table". After a worker has
finished migrating the rows, it deletes those rows from the lock table
if successful, or unlocks them if unsuccessful. Once the migration is
complete, the lock table should be empty.